### PR TITLE
Services Rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ func main() {
 	}
 }
  ```
+
+## Benchmarks
+Using `DefaultClient`, `SWbemServices` or `SWbemServicesConnection` differ in a number
+of setup calls doing to perform each query (from the most to the least).
+
+Estimated overhead is shown below:
+```
+BenchmarkQuery_DefaultClient   5000  33529798 ns/op
+BenchmarkQuery_SWbemServices   5000  32031199 ns/op
+BenchmarkQuery_SWbemConnection 5000  30099403 ns/op
+```
+
+You could reproduce the results on your machine running:
+```bash
+go test -run=NONE -bench=Query -benchtime=120s
+```

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,77 @@
+package wmi
+
+import "testing"
+
+//Run all benchmarks (should run for at least 60s to get a stable number):
+//go test -run=NONE -bench=. -benchtime=120s
+
+// All Query benchmarks:
+// go test -run=NONE -bench=Query -benchtime=120s
+
+// go test -run=NONE -bench=Query_DefaultClient -benchtime=120s
+func BenchmarkQuery_DefaultClient(b *testing.B) {
+	var dst []Win32_OperatingSystem
+	q := CreateQuery(&dst, "")
+	for n := 0; n < b.N; n++ {
+		errQuery := Query(q, &dst)
+		if errQuery != nil {
+			b.Fatalf("Query%d: %s", n, errQuery)
+		}
+		count := len(dst)
+		if count < 1 {
+			b.Fatalf("Query%d: no results found for Win32_OperatingSystem", n)
+		}
+	}
+}
+
+// go test -run=NONE -bench=Query_SWbemServices -benchtime=120s
+func BenchmarkQuery_SWbemServices(b *testing.B) {
+	s, err := NewSWbemServices()
+	if err != nil {
+		b.Fatalf("InitializeSWbemServices: %s", err)
+	}
+
+	var dst []Win32_OperatingSystem
+	q := CreateQuery(&dst, "")
+	for n := 0; n < b.N; n++ {
+		errQuery := s.Query(q, &dst)
+		if errQuery != nil {
+			b.Fatalf("Query%d: %s", n, errQuery)
+		}
+		count := len(dst)
+		if count < 1 {
+			b.Fatalf("Query%d: no results found for Win32_OperatingSystem", n)
+		}
+	}
+
+	errClose := s.Close()
+	if errClose != nil {
+		b.Fatalf("Close: %s", errClose)
+	}
+}
+
+// go test -run=NONE -bench=Query_SWbemConnection -benchtime=120s
+func BenchmarkQuery_SWbemConnection(b *testing.B) {
+	s, err := ConnectSWbemServices() // Note here
+	if err != nil {
+		b.Fatalf("InitializeSWbemServices: %s", err)
+	}
+
+	var dst []Win32_OperatingSystem
+	q := CreateQuery(&dst, "")
+	for n := 0; n < b.N; n++ {
+		errQuery := s.Query(q, &dst)
+		if errQuery != nil {
+			b.Fatalf("Query%d: %s", n, errQuery)
+		}
+		count := len(dst)
+		if count < 1 {
+			b.Fatalf("Query%d: no results found for Win32_OperatingSystem", n)
+		}
+	}
+
+	errClose := s.Close()
+	if errClose != nil {
+		b.Fatalf("Close: %s", errClose)
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -1,0 +1,241 @@
+// +build windows
+
+package wmi
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hashicorp/go-multierror"
+	"github.com/scjalliance/comshim"
+	"reflect"
+	"sync"
+
+	"github.com/go-ole/go-ole"
+	"github.com/go-ole/go-ole/oleutil"
+)
+
+// SWbemServicesConnection is used to access SWbemServices methods of the
+// single server.
+//
+// Ref: https://docs.microsoft.com/en-us/windows/desktop/wmisdk/swbemservices
+type SWbemServicesConnection struct {
+	sync.Mutex
+	Decoder
+
+	sWbemServices    *ole.IDispatch // This is for calls.
+	SWbemServicesRaw *ole.VARIANT   // This is for `.Clear()`.
+}
+
+func ConnectSWbemServices(connectServerArgs ...interface{}) (conn *SWbemServicesConnection, err error) {
+	services, err := NewSWbemServices()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := services.Close(); closeErr != nil {
+			err = multierror.Append(err, closeErr)
+		}
+	}()
+	return services.ConnectServer(connectServerArgs...)
+}
+
+func (s *SWbemServices) ConnectServer(args ...interface{}) (c *SWbemServicesConnection, err error) {
+	// Notify that we are going to use COM. We will care about at least one
+	// reference for connection.
+	comshim.Add(1)
+	defer func() {
+		if err != nil {
+			comshim.Done()
+		}
+	}()
+
+	serviceRaw, err := oleutil.CallMethod(s.sWbemLocator, "ConnectServer", args...)
+	if err != nil {
+		return nil, fmt.Errorf("SWbemServices ConnectServer error; %v", err)
+	}
+	service := serviceRaw.ToIDispatch()
+	if service == nil {
+		return nil, errors.New("SWbemServices IDispatch returned nil")
+	}
+
+	conn := SWbemServicesConnection{
+		Decoder:          s.Decoder,
+		sWbemServices:    service,
+		SWbemServicesRaw: serviceRaw,
+	}
+	return &conn, nil
+}
+
+// Close will clear and release all of the SWbemServicesConnection resources.
+func (s *SWbemServicesConnection) Close() error {
+	s.Lock()
+	defer s.Unlock()
+	if s.sWbemServices == nil {
+		return nil
+	}
+	err := s.SWbemServicesRaw.Clear()
+	if err != nil {
+		return err
+	}
+	s.SWbemServicesRaw = nil
+	s.sWbemServices.Release()
+	s.sWbemServices = nil
+	comshim.Done()
+	return nil
+}
+
+// Query runs the WQL query using a SWbemServicesConnection instance and appends
+// the values to dst.
+func (s *SWbemServicesConnection) Query(query string, dst interface{}) error {
+	s.Lock()
+	if s.sWbemServices == nil {
+		s.Unlock()
+		return fmt.Errorf("SWbemServicesConnection has been closed")
+	}
+	s.Unlock()
+
+	sliceRefl := reflect.ValueOf(dst)
+	if sliceRefl.Kind() != reflect.Ptr || sliceRefl.IsNil() {
+		return ErrInvalidEntityType
+	}
+	sliceRefl = sliceRefl.Elem() // "Dereference" pointer.
+
+	argType, elemType := checkMultiArg(sliceRefl)
+	if argType == multiArgTypeInvalid {
+		return ErrInvalidEntityType
+	}
+
+	return s.query(query, &queryDst{
+		dst:         sliceRefl,
+		dsArgType:   argType,
+		dstElemType: elemType,
+	})
+}
+
+type queryDst struct {
+	dst         reflect.Value
+	dsArgType   multiArgType
+	dstElemType reflect.Type
+}
+
+func (s *SWbemServicesConnection) query(query string, dst *queryDst) (err error) {
+	// result is a SWBemObjectSet
+	resultRaw, err := oleutil.CallMethod(s.sWbemServices, "ExecQuery", query)
+	if err != nil {
+		return err
+	}
+	result := resultRaw.ToIDispatch()
+	defer func() {
+		if clErr := resultRaw.Clear(); clErr != nil {
+			err = multierror.Append(err, clErr)
+		}
+	}()
+
+	count, err := oleInt64(result, "Count")
+	if err != nil {
+		return err
+	}
+
+	enumProperty, err := result.GetProperty("_NewEnum")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if clErr := enumProperty.Clear(); clErr != nil {
+			err = multierror.Append(err, clErr)
+		}
+	}()
+
+	enum, err := enumProperty.ToIUnknown().IEnumVARIANT(ole.IID_IEnumVariant)
+	if err != nil {
+		return err
+	}
+	if enum == nil {
+		return fmt.Errorf("can't get IEnumVARIANT, enum is nil")
+	}
+	defer enum.Release()
+
+	// Initialize a slice with Count capacity
+	dst.dst.Set(reflect.MakeSlice(dst.dst.Type(), 0, int(count)))
+
+	var errFieldMismatch error
+	for itemRaw, length, err := enum.Next(1); length > 0; itemRaw, length, err = enum.Next(1) {
+		if err != nil {
+			return err
+		}
+
+		// Closure for defer in the loop.
+		err := func() error {
+			// item is a SWbemObject, but really a Win32_Process
+			item := itemRaw.ToIDispatch()
+			defer item.Release()
+
+			ev := reflect.New(dst.dstElemType)
+			if err = s.Unmarshal(item, ev.Interface()); err != nil {
+				if _, ok := err.(*ErrFieldMismatch); ok {
+					// We continue loading entities even in the face of field mismatch errors.
+					// If we encounter any other error, that other error is returned. Otherwise,
+					// an ErrFieldMismatch is returned.
+					errFieldMismatch = multierror.Append(errFieldMismatch, err)
+				} else {
+					return err
+				}
+			}
+
+			if dst.dsArgType != multiArgTypeStructPtr {
+				ev = ev.Elem()
+			}
+			dst.dst.Set(reflect.Append(dst.dst, ev))
+
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	}
+	return errFieldMismatch
+}
+
+type multiArgType int
+
+const (
+	multiArgTypeInvalid multiArgType = iota
+	multiArgTypeStruct
+	multiArgTypeStructPtr
+)
+
+// checkMultiArg checks that v has type []S, []*S for some struct type S.
+//
+// It returns what category the slice's elements are, and the reflect.Type
+// that represents S.
+func checkMultiArg(v reflect.Value) (m multiArgType, elemType reflect.Type) {
+	if v.Kind() != reflect.Slice {
+		return multiArgTypeInvalid, nil
+	}
+	elemType = v.Type().Elem()
+	switch elemType.Kind() {
+	case reflect.Struct:
+		return multiArgTypeStruct, elemType
+	case reflect.Ptr:
+		elemType = elemType.Elem()
+		if elemType.Kind() == reflect.Struct {
+			return multiArgTypeStructPtr, elemType
+		}
+	}
+	return multiArgTypeInvalid, nil
+}
+
+func oleInt64(item *ole.IDispatch, prop string) (val int64, err error) {
+	v, err := oleutil.GetProperty(item, prop)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if clErr := v.Clear(); clErr != nil {
+			err = multierror.Append(err, clErr)
+		}
+	}()
+
+	i := int64(v.Val)
+	return i, nil
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -11,7 +11,7 @@ import (
 func TestSWbemServicesConnection(t *testing.T) {
 	s, err := ConnectSWbemServices()
 	if err != nil {
-		t.Fatalf("InitializeSWbemServices: %s", err)
+		t.Fatalf("ConnectSWbemServices: %s", err)
 	}
 
 	var dst []Win32_OperatingSystem
@@ -57,7 +57,7 @@ func TestSWbemServicesConnection_Get(t *testing.T) {
 		t.Fatalf("Failed to query current u; %s", err)
 	}
 
-	// Try to find current user account and check SID strings.
+	// Try to find current user account by its SID.
 	var currentUserAccount userAccount
 	for _, u := range loggedUsers {
 		var account userAccount
@@ -74,6 +74,7 @@ func TestSWbemServicesConnection_Get(t *testing.T) {
 
 	t.Logf("Expected user session; %+v", currentUserAccount)
 
+	// And now check domain/username to ensure we got the right user.
 	parts := strings.SplitN(osUser.Username, `\`, 2)
 	osUserDomain, osUserName := parts[0], parts[1]
 	if currentUserAccount.Name != osUserName {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,29 @@
+package wmi
+
+import "testing"
+
+// Just a smoke test of SWbemServicesConnection API. More detailed ones has
+// been done at the upper levels of abstraction.
+func TestSWbemServicesConnection(t *testing.T) {
+	s, err := ConnectSWbemServices() // Note here
+	if err != nil {
+		t.Fatalf("InitializeSWbemServices: %s", err)
+	}
+
+	var dst []Win32_OperatingSystem
+	q := CreateQuery(&dst, "")
+	errQuery := s.Query(q, &dst)
+	if errQuery != nil {
+		t.Fatalf("Query: %s", errQuery)
+	}
+
+	count := len(dst)
+	if count < 1 {
+		t.Fatalf("Query: no results found for Win32_OperatingSystem")
+	}
+
+	errClose := s.Close()
+	if errClose != nil {
+		t.Fatalf("Close: %s", errClose)
+	}
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,11 +1,15 @@
 package wmi
 
-import "testing"
+import (
+	"os/user"
+	"strings"
+	"testing"
+)
 
 // Just a smoke test of SWbemServicesConnection API. More detailed ones has
 // been done at the upper levels of abstraction.
 func TestSWbemServicesConnection(t *testing.T) {
-	s, err := ConnectSWbemServices() // Note here
+	s, err := ConnectSWbemServices()
 	if err != nil {
 		t.Fatalf("InitializeSWbemServices: %s", err)
 	}
@@ -25,5 +29,57 @@ func TestSWbemServicesConnection(t *testing.T) {
 	errClose := s.Close()
 	if errClose != nil {
 		t.Fatalf("Close: %s", errClose)
+	}
+}
+
+type userAccount struct {
+	SID    string
+	Name   string
+	Domain string
+}
+
+func TestSWbemServicesConnection_Get(t *testing.T) {
+	s, err := ConnectSWbemServices()
+	if err != nil {
+		t.Fatalf("InitializeSWbemServices: %s", err)
+	}
+
+	// https://docs.microsoft.com/en-us/windows/desktop/cimwin32prov/win32-loggedonuser
+	var loggedUsers []struct {
+		AccountRef string `wmi:"Antecedent"`
+	}
+	if err := s.Query("SELECT * from Win32_LoggedOnUser", &loggedUsers); err != nil {
+		t.Fatalf("Failed to query Win32_LoggedOnUser; %s", err)
+	}
+
+	osUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("Failed to query current u; %s", err)
+	}
+
+	// Try to find current user account and check SID strings.
+	var currentUserAccount userAccount
+	for _, u := range loggedUsers {
+		var account userAccount
+		if err := s.Get(u.AccountRef, &account); err != nil {
+			t.Errorf("Failed to get Win32_Account using ref %q; %s", u, err)
+			continue
+		}
+
+		if account.SID == osUser.Uid {
+			currentUserAccount = account
+			break
+		}
+	}
+
+	t.Logf("Expected user session; %+v", currentUserAccount)
+
+	parts := strings.SplitN(osUser.Username, `\`, 2)
+	osUserDomain, osUserName := parts[0], parts[1]
+	if currentUserAccount.Name != osUserName {
+		t.Errorf("Got unexpected user Name; got %q, expected %q", currentUserAccount.Name, osUserName)
+	}
+	if currentUserAccount.Domain != osUserDomain {
+		t.Errorf("Got unexpected user Domain; got %q, expected %q", currentUserAccount.Domain, osUserDomain)
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,27 @@
+/*
+Package wmi provides a WQL interface for WMI on Windows.
+
+Example code to print names of running processes:
+    // When we use `wmi.CreateQuery` the name of the struct should match querying
+    // WMI class name.
+    type Win32_Process struct {
+    	PID       uint32 `wmi:"ProcessId"`
+    	Name      string
+    	UserField int `wmi:"-"`
+    }
+
+    func main() {
+    	var dst []Win32_Process
+
+	    q := wmi.CreateQuery(&dst, "")
+	    fmt.Println(q)
+
+	    if err := wmi.Query(q, &dst); err != nil {
+    		log.Fatal(err)
+    	}
+    	for _, v := range dst {
+    		fmt.Println(v.PID, v.Name)
+    	}
+    }
+*/
+package wmi

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-ole/go-ole v1.2.2 h1:HXmymm3IQ8iAfpqlbbUGLHd+SZrnmI4y1pv+WL/3R7c=
-github.com/go-ole/go-ole v1.2.2/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-ole/go-ole v1.2.2 h1:QNWhweRd9D5Py2rRVboZ2L4SEoW/dyraWJCc8bgS8kE=
+github.com/go-ole/go-ole v1.2.2/go.mod h1:pnvuG7BrDMZ8ifMurTQmxwhQM/odqm9sSqNe5BUI7v4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=

--- a/memory_test.go
+++ b/memory_test.go
@@ -4,7 +4,6 @@ package wmi
 
 import (
 	"fmt"
-	"github.com/scjalliance/comshim"
 	"os"
 	"runtime"
 	"sync"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
+	"github.com/scjalliance/comshim"
 )
 
 const memReps = 50 * 1000

--- a/swbemservices.go
+++ b/swbemservices.go
@@ -4,12 +4,12 @@ package wmi
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-multierror"
-	"github.com/scjalliance/comshim"
 	"sync"
 
 	"github.com/go-ole/go-ole"
 	"github.com/go-ole/go-ole/oleutil"
+	"github.com/hashicorp/go-multierror"
+	"github.com/scjalliance/comshim"
 )
 
 // SWbemServices is used to access wmi on a different machines or namespaces

--- a/swbemservices.go
+++ b/swbemservices.go
@@ -42,7 +42,7 @@ func NewSWbemServices() (s *SWbemServices, err error) {
 
 	locatorIUnknown, err := oleutil.CreateObject("WbemScripting.SWbemLocator")
 	if err != nil {
-		return nil, fmt.Errorf("CreateObject SWbemLocator erro; %v", err)
+		return nil, fmt.Errorf("CreateObject SWbemLocator error; %v", err)
 	} else if locatorIUnknown == nil {
 		return nil, ErrNilCreateObject
 	}

--- a/swbemservices_test.go
+++ b/swbemservices_test.go
@@ -63,50 +63,6 @@ func TestWbemQueryNamespace(t *testing.T) {
 	}
 }
 
-//Run all benchmarks (should run for at least 60s to get a stable number):
-//go test -run=NONE -bench=Version -benchtime=120s
-
-//Individual benchmarks:
-//go test -run=NONE -bench=NewVersion -benchtime=120s
-func BenchmarkNewVersion(b *testing.B) {
-	s, err := ConnectSWbemServices()
-	if err != nil {
-		b.Fatalf("InitializeSWbemServices: %s", err)
-	}
-	var dst []Win32_OperatingSystem
-	q := CreateQuery(&dst, "")
-	for n := 0; n < b.N; n++ {
-		errQuery := s.Query(q, &dst)
-		if errQuery != nil {
-			b.Fatalf("Query%d: %s", n, errQuery)
-		}
-		count := len(dst)
-		if count < 1 {
-			b.Fatalf("Query%d: no results found for Win32_OperatingSystem", n)
-		}
-	}
-	errClose := s.Close()
-	if errClose != nil {
-		b.Fatalf("Close: %s", errClose)
-	}
-}
-
-//go test -run=NONE -bench=OldVersion -benchtime=120s
-func BenchmarkOldVersion(b *testing.B) {
-	var dst []Win32_OperatingSystem
-	q := CreateQuery(&dst, "")
-	for n := 0; n < b.N; n++ {
-		errQuery := Query(q, &dst)
-		if errQuery != nil {
-			b.Fatalf("Query%d: %s", n, errQuery)
-		}
-		count := len(dst)
-		if count < 1 {
-			b.Fatalf("Query%d: no results found for Win32_OperatingSystem", n)
-		}
-	}
-}
-
 type MSFT_NetAdapter struct {
 	Name              string
 	InterfaceIndex    int

--- a/swbemservices_test.go
+++ b/swbemservices_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestWbemQuery(t *testing.T) {
-	s, err := InitializeSWbemServices(DefaultClient)
+	s, err := ConnectSWbemServices()
 	if err != nil {
 		t.Fatalf("InitializeSWbemServices: %s", err)
 	}
@@ -43,7 +43,7 @@ func TestWbemQuery(t *testing.T) {
 }
 
 func TestWbemQueryNamespace(t *testing.T) {
-	s, err := InitializeSWbemServices(DefaultClient)
+	s, err := NewSWbemServices()
 	if err != nil {
 		t.Fatalf("InitializeSWbemServices: %s", err)
 	}
@@ -69,7 +69,7 @@ func TestWbemQueryNamespace(t *testing.T) {
 //Individual benchmarks:
 //go test -run=NONE -bench=NewVersion -benchtime=120s
 func BenchmarkNewVersion(b *testing.B) {
-	s, err := InitializeSWbemServices(DefaultClient)
+	s, err := ConnectSWbemServices()
 	if err != nil {
 		b.Fatalf("InitializeSWbemServices: %s", err)
 	}

--- a/swbemservices_test.go
+++ b/swbemservices_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestWbemQuery(t *testing.T) {
-	s, err := ConnectSWbemServices()
+	s, err := NewSWbemServices()
 	if err != nil {
 		t.Fatalf("InitializeSWbemServices: %s", err)
 	}

--- a/wmi.go
+++ b/wmi.go
@@ -35,10 +35,7 @@ func QueryNamespace(query string, dst interface{}, namespace string) error {
 //
 // Query is a wrapper around DefaultClient.Query.
 func Query(query string, dst interface{}, connectServerArgs ...interface{}) error {
-	if DefaultClient.SWbemServicesClient == nil {
-		return DefaultClient.Query(query, dst, connectServerArgs...)
-	}
-	return DefaultClient.SWbemServicesClient.Query(query, dst, connectServerArgs...)
+	return DefaultClient.Query(query, dst, connectServerArgs...)
 }
 
 // CreateQuery returns a WQL query string that queries all columns of @src.

--- a/wmi.go
+++ b/wmi.go
@@ -5,9 +5,10 @@ package wmi
 import (
 	"bytes"
 	"errors"
-	"github.com/hashicorp/go-multierror"
 	"reflect"
 	"strings"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 var (
@@ -95,7 +96,7 @@ func CreateQueryFrom(src interface{}, from, where string) string {
 // to using `wmi.Query` method. Refer to benchmarks in repo README.md for more
 // info about the speed.
 type Client struct {
-	// Embed Decoder for backward-compatibility.
+	// Embedded Decoder for backward-compatibility.
 	Decoder
 
 	// SWbemServiceClient is an optional SWbemServices object that can be

--- a/wmi.go
+++ b/wmi.go
@@ -130,5 +130,6 @@ func (c *Client) Query(query string, dst interface{}, connectServerArgs ...inter
 			}
 		}()
 	}
+	client.Decoder = c.Decoder // Patch decoder to use set decoder flags inside `Query`.
 	return client.Query(query, dst, connectServerArgs...)
 }

--- a/wmi.go
+++ b/wmi.go
@@ -11,7 +11,10 @@ import (
 )
 
 var (
+	// ErrInvalidEntityType is returned in case of unsupported destination type
+	// given to the `Query` call.
 	ErrInvalidEntityType = errors.New("wmi: invalid entity type")
+
 	// ErrNilCreateObject is the error returned if CreateObject returns nil even
 	// if the error was nil.
 	ErrNilCreateObject = errors.New("wmi: create object returned nil")
@@ -24,14 +27,11 @@ func QueryNamespace(query string, dst interface{}, namespace string) error {
 
 // Query runs the WQL query and appends the values to dst.
 //
-// dst must have type *[]S or *[]*S, for some struct type S. Fields selected in
-// the query must have the same name in dst. Supported types are all signed and
-// unsigned integers, time.Time, string, bool, or a pointer to one of those.
-// Array types are not supported.
+// More info about result unmarshalling is available in `Decoder.Unmarshal` doc.
 //
 // By default, the local machine and default namespace are used. These can be
-// changed using connectServerArgs. See
-// http://msdn.microsoft.com/en-us/library/aa393720.aspx for details.
+// changed using connectServerArgs. See a reference below for details.
+// https://docs.microsoft.com/en-us/windows/desktop/wmisdk/swbemlocator-connectserver
 //
 // Query is a wrapper around DefaultClient.Query.
 func Query(query string, dst interface{}, connectServerArgs ...interface{}) error {
@@ -89,7 +89,14 @@ func CreateQueryFrom(src interface{}, from, where string) string {
 
 // A Client is an WMI query client.
 //
-// Its zero value (DefaultClient) is a usable client.
+// Its zero value (`DefaultClient`) is a usable client.
+//
+// Client provides an ability to modify result decoding params by modifying
+// embedded `.Decoder` properties.
+//
+// Important: Using zero-value Client does not speed up your queries comparing
+// to using `wmi.Query` method. Refer to benchmarks in repo README.md for more
+// info about the speed.
 type Client struct {
 	// Embed Decoder for backward-compatibility.
 	Decoder
@@ -105,14 +112,11 @@ var DefaultClient = &Client{}
 
 // Query runs the WQL query and appends the values to dst.
 //
-// dst must have type *[]S or *[]*S, for some struct type S. Fields selected in
-// the query must have the same name in dst. Supported types are all signed and
-// unsigned integers, time.Time, string, bool, or a pointer to one of those.
-// Array types are not supported.
+// More info about result unmarshalling is available in `Decoder.Unmarshal` doc.
 //
 // By default, the local machine and default namespace are used. These can be
-// changed using connectServerArgs. See
-// http://msdn.microsoft.com/en-us/library/aa393720.aspx for details.
+// changed using connectServerArgs. See a reference below for details.
+// https://docs.microsoft.com/en-us/windows/desktop/wmisdk/swbemlocator-connectserver
 func (c *Client) Query(query string, dst interface{}, connectServerArgs ...interface{}) (err error) {
 	client := c.SWbemServicesClient
 	if client == nil {


### PR DESCRIPTION
Had to refactor original `SWebmServices` API to allow convenient subsequent calls inside single WMI server connection.

Sample usage is shown in `TestSWbemServicesConnection_Get`.

More usages for WMI results with reference fields are coming in separate PR.

cc @vl-bizone @kolesnikovae