### PR TITLE
Feature: References

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -57,7 +57,7 @@ func (s *SWbemServices) ConnectServer(args ...interface{}) (c *SWbemServicesConn
 	//  Be aware of reflections and COM usage.
 	defer func() {
 		if r := recover(); r != nil {
-			err = multierror.Append(err, fmt.Errorf("runtime panic; %v", err))
+			err = multierror.Append(err, fmt.Errorf("runtime panic; %v", r))
 		}
 	}()
 
@@ -155,7 +155,7 @@ func (s *SWbemServicesConnection) Get(path string, dst interface{}) (err error) 
 	//  Be aware of reflections and COM usage.
 	defer func() {
 		if r := recover(); r != nil {
-			err = multierror.Append(err, fmt.Errorf("runtime panic; %v", err))
+			err = multierror.Append(err, fmt.Errorf("runtime panic; %v", r))
 		}
 	}()
 
@@ -188,7 +188,7 @@ func (s *SWbemServicesConnection) query(query string, dst *queryDst) (err error)
 	//  Be aware of reflections and COM usage.
 	defer func() {
 		if r := recover(); r != nil {
-			err = multierror.Append(err, fmt.Errorf("runtime panic; %v", err))
+			err = multierror.Append(err, fmt.Errorf("runtime panic; %v", r))
 		}
 	}()
 

--- a/decoder.go
+++ b/decoder.go
@@ -104,7 +104,7 @@ func (d *Decoder) Unmarshal(src *ole.IDispatch, dst interface{}) (err error) {
 	defer func() {
 		// We use lots of reflection, so always be alert!
 		if r := recover(); r != nil {
-			err = fmt.Errorf("runtime panic: %v", err)
+			err = fmt.Errorf("runtime panic: %v", r)
 		}
 	}()
 

--- a/swbemservices.go
+++ b/swbemservices.go
@@ -29,7 +29,7 @@ func NewSWbemServices() (s *SWbemServices, err error) {
 	//  Be aware of reflections and COM usage.
 	defer func() {
 		if r := recover(); r != nil {
-			err = multierror.Append(err, fmt.Errorf("runtime panic; %v", err))
+			err = multierror.Append(err, fmt.Errorf("runtime panic; %v", r))
 		}
 	}()
 

--- a/wmi.go
+++ b/wmi.go
@@ -72,7 +72,7 @@ func CreateQueryFrom(src interface{}, from, where string) string {
 	b.WriteString("SELECT ")
 	var fields []string
 	for i := 0; i < t.NumField(); i++ {
-		name := getFieldName(t.Field(i))
+		name, _ := getFieldName(t.Field(i))
 		if name == "-" {
 			continue
 		}

--- a/wmi_test.go
+++ b/wmi_test.go
@@ -30,9 +30,12 @@ func TestFieldMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected err field mismatch")
 	}
-	expectedErr := `wmi: cannot load field "Blah" into a "uint32": no such result field`
-	if err.Error() != expectedErr {
-		t.Errorf("Unexpected field mismatch error; got %q, expected %q", err, expectedErr)
+	expectedErr, ok := err.(ErrFieldMismatch)
+	if !ok {
+		t.Fatalf("Unexpected error type; got %T, expected %T", err, expectedErr)
+	}
+	if expectedErr.FieldName != "Blah" {
+		t.Errorf("Unexpected field mismatch error; got error for field %q; expected for %q", expectedErr.FieldName, "Blah")
 	}
 }
 


### PR DESCRIPTION
The change is intended to simplify querying of WMI classes that contains object references instead the objects itself, e.g.:
https://docs.microsoft.com/en-us/windows/desktop/cimwin32prov/win32-loggedonuser
https://docs.microsoft.com/en-us/windows/desktop/wmisdk/--instanceoperationevent 

It introduced a bit weird "cyclic" dependency between `Decoder` and `SWebmServices`, but it seems to be much more simple to code it one time here than to implement a DTO for every class with references a user wanted to get.

cc @vl-bizone @kolesnikovae